### PR TITLE
feat: add smart splitter for code blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4350,15 +4350,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/bindings": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "optional": true,
-            "dependencies": {
-                "file-uri-to-path": "1.0.0"
-            }
-        },
         "node_modules/bluebird": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -8018,12 +8009,6 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             }
-        },
-        "node_modules/file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "optional": true
         },
         "node_modules/filesize": {
             "version": "6.1.0",
@@ -12493,12 +12478,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
             "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
-        },
-        "node_modules/nan": {
-            "version": "2.14.2",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-            "optional": true
         },
         "node_modules/nanoid": {
             "version": "3.1.23",
@@ -24612,14 +24591,6 @@
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
             "devOptional": true
         },
-        "bindings": {
-            "version": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "optional": true,
-            "requires": {
-                "file-uri-to-path": "1.0.0"
-            }
-        },
         "bluebird": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -27540,12 +27511,6 @@
                     }
                 }
             }
-        },
-        "file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "optional": true
         },
         "filesize": {
             "version": "6.1.0",
@@ -31109,11 +31074,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
             "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
-        },
-        "nan": {
-            "version": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-            "optional": true
         },
         "nanoid": {
             "version": "3.1.23",

--- a/package.json
+++ b/package.json
@@ -21,17 +21,10 @@
         "eject": "react-scripts eject"
     },
     "eslintConfig": {
-        "extends": [
-            "react-app",
-            "react-app/jest"
-        ]
+        "extends": ["react-app", "react-app/jest"]
     },
     "browserslist": {
-        "production": [
-            ">0.2%",
-            "not dead",
-            "not op_mini all"
-        ],
+        "production": [">0.2%", "not dead", "not op_mini all"],
         "development": [
             "last 1 chrome version",
             "last 1 firefox version",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,17 @@
         "eject": "react-scripts eject"
     },
     "eslintConfig": {
-        "extends": ["react-app", "react-app/jest"]
+        "extends": [
+            "react-app",
+            "react-app/jest"
+        ]
     },
     "browserslist": {
-        "production": [">0.2%", "not dead", "not op_mini all"],
+        "production": [
+            ">0.2%",
+            "not dead",
+            "not op_mini all"
+        ],
         "development": [
             "last 1 chrome version",
             "last 1 firefox version",

--- a/src/components/CodeWrapper.tsx
+++ b/src/components/CodeWrapper.tsx
@@ -1,5 +1,4 @@
 import { KeyboardEvent, FC, useState } from "react";
-// import { invalidInputs } from "../utils/input";
 import { Cursor } from "./Cursor";
 import { WordList } from "components/WordList";
 
@@ -7,10 +6,9 @@ interface ICodeWrapper {
   codeBlock: string;
 }
 
-// TODO: this will have to be tweaked based on font size
-export const curXStep = 0.582;
-export const curYStep = 7.5;
-export const cursorStart = { x: 0, y: 0.1875 };
+const curXStep = 0.582;
+const curYStep = 7.5;
+const cursorStart = { x: 0, y: 0.1875 };
 
 export const CodeWrapper: FC<ICodeWrapper> = ({ codeBlock }) => {
   const [cursorPos, setCursorPos] = useState(cursorStart);
@@ -59,4 +57,38 @@ export const CodeWrapper: FC<ICodeWrapper> = ({ codeBlock }) => {
       </div>
     </>
   );
+};
+
+const smartSplit = (str: string | null): string[] => {
+  let words: string[] = [];
+  if (str == null) return words;
+
+  str = str.trim();
+
+  let word = "";
+  for (let i = 0; i <= str.length; i++) {
+    if (str[i] === " " || i === str.length) {
+      if (str[i + 1] === " ") {
+        if (word) words.push(word);
+        word = "&#x9;"; // https://www.compart.com/en/unicode/U+0009
+        i++;
+      }
+      words.push(word);
+      word = "";
+    } else if (str[i] === "\n") {
+      words.push(word);
+      words.push("&#xA;"); // https://www.compart.com/en/unicode/U+000A
+      word = "";
+    } else {
+      word += str[i];
+    }
+  }
+  return words;
+};
+
+export const testing = {
+  curXStep,
+  curYStep,
+  cursorStart,
+  smartSplit,
 };

--- a/src/components/tests/CodeWrapper.test.tsx
+++ b/src/components/tests/CodeWrapper.test.tsx
@@ -1,6 +1,8 @@
 import { render, fireEvent, screen } from "@testing-library/react";
-import { CodeWrapper, curXStep, cursorStart } from "components/CodeWrapper";
+import { CodeWrapper } from "components/CodeWrapper";
 import "@testing-library/jest-dom/extend-expect";
+import { testing } from "../CodeWrapper";
+const { smartSplit, curXStep, cursorStart } = testing;
 
 describe("CodeWrapper", () => {
   beforeEach(() => {
@@ -33,5 +35,85 @@ describe("CodeWrapper", () => {
 
     expect(cursor).toHaveStyle(`left: ${xPos}em`);
     expect(cursor).toHaveStyle(`top: ${yPos}em`);
+  });
+});
+
+describe("smart splitting", () => {
+  it("blank codeBlock", () => {
+    expect(smartSplit("")).toEqual([""]);
+  });
+
+  it("one line basic sentence", () => {
+    const str = "this app is sick";
+    const result = ["this", "app", "is", "sick"];
+    expect(smartSplit(str)).toEqual(result);
+  });
+
+  it("poorly spaced one line basic sentence", () => {
+    const str = " this app is sick ";
+    const result = ["this", "app", "is", "sick"];
+    expect(smartSplit(str)).toEqual(result);
+  });
+
+  it("one line sentence with tabs", () => {
+    const tab = "&#x9;";
+    const str = "these  are  tab  spaced";
+    const result = ["these", tab, "are", tab, "tab", tab, "spaced"];
+    expect(smartSplit(str)).toEqual(result);
+  });
+
+  it("simply multiline", () => {
+    const cr = "&#xA;";
+    const str = `these
+are
+lines`;
+    const result = ["these", cr, "are", cr, "lines"];
+    expect(smartSplit(str)).toEqual(result);
+  });
+
+  it("codeblock: basic if", () => {
+    const cr = "&#xA;";
+    const tab = "&#x9;";
+    const str = `if (true) {
+  const foo = 'bar'
+}`;
+    const result = [
+      "if",
+      "(true)",
+      "{",
+      cr,
+      tab,
+      "const",
+      "foo",
+      "=",
+      "'bar'",
+      cr,
+      "}",
+    ];
+    expect(smartSplit(str)).toEqual(result);
+  });
+
+  it("codeblock: basic if", () => {
+    const cr = "&#xA;";
+    const tab = "&#x9;";
+    const str = `def func:
+  if foo:
+    return True
+
+`;
+    const result = [
+      "def",
+      "func:",
+      cr,
+      tab,
+      "if",
+      "foo:",
+      cr,
+      tab,
+      tab,
+      "return",
+      "True",
+    ];
+    expect(smartSplit(str)).toEqual(result);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5050,11 +5050,6 @@
     "loader-utils" "^2.0.0"
     "schema-utils" "^3.0.0"
 
-"file-uri-to-path@1.0.0":
-  "integrity" "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-  "resolved" "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz"
-  "version" "1.0.0"
-
 "filesize@6.1.0":
   "integrity" "sha512-LpCHtPQ3sFx67z+uh2HnSyWSLLu5Jxo21795uRDuar/EOuYWXib5EmPaGIBuSnRqH2IODiKA2k5re/K9OnN/Yg=="
   "resolved" "https://registry.npmjs.org/filesize/-/filesize-6.1.0.tgz"


### PR DESCRIPTION
splits code into words, substituting _**2 space tabs**_ for `&#x9;` and new lines for `&#xA`

eg:
```
def func:
  if foo:
    return True
```
becomes like `["def", "func:", newline, tab, "if", "foo:", newline, tab, tab, "return", "True"]`
or `["def", "func:", '&#xA;', '&#x9;', "if", "foo:", '&#xA;', '&#x9;', '&#x9;', "return", "True" ] `

awaiting merging of `WordList` into `CodeWrapper` to move onto proper rendering of tabs, NL/