### PR TITLE
Print formatted code

### DIFF
--- a/src/components/CodeWrapper.tsx
+++ b/src/components/CodeWrapper.tsx
@@ -176,32 +176,35 @@ export const CodeWrapper: FC<ICodeWrapper> = ({ codeBlock }) => {
 /**
  * Tokenizes a formatted multi-line code block
  * @param {(string | null)} str - a code block
- * @returns {string[]} array of words and format strings
+ * @returns {string[][] | void} array of words and format strings per line
  */
-const smartSplit = (str: string | null): string[] => {
-  let words: string[] = [];
-  if (str == null) return words;
+const smartSplit = (str: string | null): string[][] | void => {
+  let words: string[][] = [];
+  if (str == null || str === "") return;
 
   str = str.trim();
 
   let word = "";
+  let line = [];
   for (let i = 0; i <= str.length; i++) {
     if (str[i] === " " || i === str.length) {
       if (str[i + 1] === " ") {
-        if (word) words.push(word);
-        word = "&#x9;"; // https://www.compart.com/en/unicode/U+0009
+        if (word) line.push(word);
+        word = tab;
         i++;
       }
-      words.push(word);
+      line.push(word);
       word = "";
     } else if (str[i] === "\n") {
-      words.push(word);
-      words.push("&#xA;"); // https://www.compart.com/en/unicode/U+000A
+      line.push(word);
+      words.push(line);
+      line = [];
       word = "";
     } else {
       word += str[i];
     }
   }
+  words.push(line);
   return words;
 };
 
@@ -210,4 +213,5 @@ export const testing = {
   curYStep,
   cursorStart,
   smartSplit,
+  tab,
 };

--- a/src/components/CodeWrapper.tsx
+++ b/src/components/CodeWrapper.tsx
@@ -1,6 +1,7 @@
 import { KeyboardEvent, FC, useState } from "react";
 import { Cursor } from "./Cursor";
 import { Word } from "components/Word";
+import { Tab } from "./Tab";
 
 interface ICodeWrapper {
   codeBlock: string;
@@ -18,7 +19,11 @@ const curXStep = 0.582;
 const curYStep = 7.5;
 const cursorStart = { x: 0, y: 0.1875 };
 
+const tab = "&#x9;"; // https://www.compart.com/en/unicode/U+0009
+
 export const CodeWrapper: FC<ICodeWrapper> = ({ codeBlock }) => {
+  let wordIdx = 0;
+  const wordList = smartSplit(codeBlock);
   const [cursorPos, setCursorPos] = useState(cursorStart);
   const [typed, setTyped] = useState<WordListElement>({
     currentWordId: 0,
@@ -145,16 +150,29 @@ export const CodeWrapper: FC<ICodeWrapper> = ({ codeBlock }) => {
     <>
       <div className="CodeWrapper">
         <Cursor hidden={false} xpad={cursorPos.x} ypad={cursorPos.y} />
-        <div className="WordList">
-          {codeBlock.split(" ").map((wd, i) => (
-            <Word
-              key={i}
-              text={wd}
-              value={getBareElements(bisectWord(i)).split("")}
-              isComplete={isWordComplete(i)}
-            />
-          ))}
-        </div>
+        {wordList.map((line, lineNum) => {
+          return (
+            <div className="flex flex-wrap" key={lineNum}>
+              {line.map((wd, wdNum) => {
+                if (wd === tab)
+                  return (
+                    <Tab key={`${lineNum}:${wdNum}`} spaceSize={curXStep} />
+                  );
+                const i = wordIdx;
+                wordIdx++;
+                return (
+                  <Word
+                    key={i}
+                    text={wd}
+                    value={getBareElements(bisectWord(i)).split("")}
+                    isComplete={isWordComplete(i)}
+                  />
+                );
+              })}
+            </div>
+          );
+        })}
+        <div className="WordList"></div>
       </div>
       <div className="grid justify-items-center py-2">
         <p>&laquo;main content&raquo;</p>
@@ -176,11 +194,11 @@ export const CodeWrapper: FC<ICodeWrapper> = ({ codeBlock }) => {
 /**
  * Tokenizes a formatted multi-line code block
  * @param {(string | null)} str - a code block
- * @returns {string[][] | void} array of words and format strings per line
+ * @returns {string[][]} array of words and format strings per line
  */
-const smartSplit = (str: string | null): string[][] | void => {
+const smartSplit = (str: string | null): string[][] => {
   let words: string[][] = [];
-  if (str == null || str === "") return;
+  if (str == null || str === "") return words;
 
   str = str.trim();
 

--- a/src/components/Practice.tsx
+++ b/src/components/Practice.tsx
@@ -1,9 +1,14 @@
 import { CodeWrapper } from "./CodeWrapper";
 
 function Practice() {
+  const code = `
+if (true) {
+  return 'foo'
+}
+  `;
   return (
     <main>
-      <CodeWrapper codeBlock="The quick brown fox jumped over the lazy dog" />
+      <CodeWrapper codeBlock={code} />
     </main>
   );
 }

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -1,0 +1,13 @@
+import { FC } from "react";
+
+interface ITab {
+  spaceSize: number;
+}
+
+export const Tab: FC<ITab> = ({ spaceSize }) => {
+  return (
+    <span
+      style={{ display: "inline-block", marginLeft: `${spaceSize * 2}em` }}
+    ></span>
+  );
+};

--- a/src/components/Word.tsx
+++ b/src/components/Word.tsx
@@ -7,17 +7,17 @@ interface IWord {
   isComplete?: boolean;
 }
 
-interface IWordElement {
+type WordElement = {
   index: number;
   char: string;
   isHit?: boolean;
-}
+};
 
 const Word: React.FC<IWord> = ({ text, value, isComplete }) => {
   const originWord = text.split("");
 
   const createWord = () => {
-    let spreadTyped: IWordElement[] = [];
+    let spreadTyped: WordElement[] = [];
 
     if (value) {
       spreadTyped = [

--- a/src/components/tests/CodeWrapper.test.tsx
+++ b/src/components/tests/CodeWrapper.test.tsx
@@ -2,7 +2,7 @@ import { render, fireEvent, screen } from "@testing-library/react";
 import { CodeWrapper } from "components/CodeWrapper";
 import "@testing-library/jest-dom/extend-expect";
 import { testing } from "../CodeWrapper";
-const { smartSplit, curXStep, cursorStart } = testing;
+const { smartSplit, curXStep, cursorStart, tab } = testing;
 
 describe("CodeWrapper", () => {
   beforeEach(() => {
@@ -42,79 +42,57 @@ describe("CodeWrapper", () => {
 
 describe("smart splitting", () => {
   it("blank codeBlock", () => {
-    expect(smartSplit("")).toEqual([""]);
+    expect(smartSplit("")).toBeUndefined();
   });
 
   it("one line basic sentence", () => {
     const str = "this app is sick";
-    const result = ["this", "app", "is", "sick"];
+    const result = [["this", "app", "is", "sick"]];
     expect(smartSplit(str)).toEqual(result);
   });
 
   it("poorly spaced one line basic sentence", () => {
     const str = " this app is sick ";
-    const result = ["this", "app", "is", "sick"];
+    const result = [["this", "app", "is", "sick"]];
     expect(smartSplit(str)).toEqual(result);
   });
 
   it("one line sentence with tabs", () => {
-    const tab = "&#x9;";
     const str = "these  are  tab  spaced";
-    const result = ["these", tab, "are", tab, "tab", tab, "spaced"];
+    const result = [["these", tab, "are", tab, "tab", tab, "spaced"]];
     expect(smartSplit(str)).toEqual(result);
   });
 
   it("simply multiline", () => {
-    const cr = "&#xA;";
     const str = `these
 are
 lines`;
-    const result = ["these", cr, "are", cr, "lines"];
+    const result = [["these"], ["are"], ["lines"]];
     expect(smartSplit(str)).toEqual(result);
   });
 
   it("codeblock: basic if", () => {
-    const cr = "&#xA;";
-    const tab = "&#x9;";
     const str = `if (true) {
   const foo = 'bar'
 }`;
     const result = [
-      "if",
-      "(true)",
-      "{",
-      cr,
-      tab,
-      "const",
-      "foo",
-      "=",
-      "'bar'",
-      cr,
-      "}",
+      ["if", "(true)", "{"],
+      [tab, "const", "foo", "=", "'bar'"],
+      ["}"],
     ];
     expect(smartSplit(str)).toEqual(result);
   });
 
   it("codeblock: basic if", () => {
-    const cr = "&#xA;";
-    const tab = "&#x9;";
     const str = `def func:
   if foo:
     return True
 
-`;
+  `;
     const result = [
-      "def",
-      "func:",
-      cr,
-      tab,
-      "if",
-      "foo:",
-      cr,
-      tab,
-      tab,
-      "return",
-      "True",
+      ["def", "func:"],
+      [tab, "if", "foo:"],
+      [tab, tab, "return", "True"],
     ];
     expect(smartSplit(str)).toEqual(result);
   });

--- a/src/components/tests/CodeWrapper.test.tsx
+++ b/src/components/tests/CodeWrapper.test.tsx
@@ -42,7 +42,7 @@ describe("CodeWrapper", () => {
 
 describe("smart splitting", () => {
   it("blank codeBlock", () => {
-    expect(smartSplit("")).toBeUndefined();
+    expect(smartSplit("")).toEqual([]);
   });
 
   it("one line basic sentence", () => {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -60,7 +60,7 @@ input {
 }
 
 .WordList {
-  @apply flex flex-wrap text-2xl;
+  @apply text-2xl;
   font-variant: no-common-ligatures;
 }
 


### PR DESCRIPTION
closes #13 
![image](https://user-images.githubusercontent.com/66286082/129496343-9b83b53b-5c92-4b58-a73a-550689c7fdcb.png)

This PR does not address the cursor movement along the formatted code. Cursor just moves in a straight line, and honestly not sure why but looks worse.
